### PR TITLE
Add --keep-fs: a flag to preserve existing FS while flashing

### DIFF
--- a/common/fwbundle/fw_bundle.go
+++ b/common/fwbundle/fw_bundle.go
@@ -25,9 +25,13 @@ import (
 	"sort"
 	"time"
 
-	"github.com/mongoose-os/mos/mos/ourutil"
 	"github.com/cesanta/errors"
 	"github.com/golang/glog"
+	"github.com/mongoose-os/mos/mos/ourutil"
+)
+
+const (
+	FSPartType = "fs"
 )
 
 type FirmwareBundle struct {

--- a/mos/flags/flags.go
+++ b/mos/flags/flags.go
@@ -88,6 +88,7 @@ var (
 	GDBServerCmd = flag.String("gdb-server-cmd", "/usr/local/bin/serve_core.py", "")
 
 	KeepTempFiles = flag.Bool("keep-temp-files", false, "keep temp files after the build is done (by default they are in ~/.mos/tmp)")
+	KeepFS        = flag.Bool("keep-fs", false, "When flashing, skip the filesystem parts")
 )
 
 func Platform() string {

--- a/mos/flash.go
+++ b/mos/flash.go
@@ -172,15 +172,19 @@ func flash(ctx context.Context, devConn dev.DevConn) error {
 	switch strings.ToLower(fw.Platform) {
 	case "cc3200":
 		cc3200FlashOpts.Port = port
+		cc3200FlashOpts.KeepFS = *flags.KeepFS
 		err = cc3200.Flash(fw, &cc3200FlashOpts)
 	case "cc3220":
 		cc3220FlashOpts.Port = port
+		cc3220FlashOpts.KeepFS = *flags.KeepFS
 		err = cc3220.Flash(fw, &cc3220FlashOpts)
 	case "esp32":
 		espFlashOpts.ControlPort = port
+		espFlashOpts.KeepFS = *flags.KeepFS
 		err = espFlasher.Flash(esp.ChipESP32, fw, &espFlashOpts)
 	case "esp8266":
 		espFlashOpts.ControlPort = port
+		espFlashOpts.KeepFS = *flags.KeepFS
 		err = espFlasher.Flash(esp.ChipESP8266, fw, &espFlashOpts)
 	case "stm32":
 		// Ideally we'd like to find mounted directory corresponding to the selected port.
@@ -203,8 +207,10 @@ func flash(ctx context.Context, devConn dev.DevConn) error {
 			}
 		}
 		stm32FlashOpts.ShareName = port
+		stm32FlashOpts.KeepFS = *flags.KeepFS
 		err = stm32.Flash(fw, &stm32FlashOpts)
 	case "rs14100":
+		rs14100FlashOpts.KeepFS = *flags.KeepFS
 		err = rs14100.Flash(fw, &rs14100FlashOpts)
 	default:
 		err = errors.Errorf("%s: unsupported platform '%s'", *firmware, fw.Platform)

--- a/mos/flash/cc3200/flasher.go
+++ b/mos/flash/cc3200/flasher.go
@@ -9,16 +9,17 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/cesanta/errors"
+	"github.com/cesanta/go-serial/serial"
 	"github.com/mongoose-os/mos/common/fwbundle"
 	"github.com/mongoose-os/mos/mos/flash/cc32xx"
 	"github.com/mongoose-os/mos/mos/flash/common"
-	"github.com/cesanta/errors"
-	"github.com/cesanta/go-serial/serial"
 )
 
 type FlashOpts struct {
 	Port           string
 	FormatSLFSSize int
+	KeepFS         bool
 }
 
 const (
@@ -42,6 +43,12 @@ func isKnownPartType(pt string) bool {
 
 func Flash(fw *fwbundle.FirmwareBundle, opts *FlashOpts) error {
 	var files []*fileInfo
+
+	if opts.KeepFS {
+		// It's not easy: we always format SLFS regardless.
+		// We'd need to read the fs first to preserve it.
+		return errors.Errorf("--keep-fs is not supportef for CC3200")
+	}
 
 	parts := []*fwbundle.FirmwarePart{}
 	for _, p := range fw.Parts {

--- a/mos/flash/cc3220/flasher.go
+++ b/mos/flash/cc3220/flasher.go
@@ -8,17 +8,18 @@
 package cc3220
 
 import (
+	"github.com/cesanta/errors"
+	"github.com/cesanta/go-serial/serial"
 	"github.com/mongoose-os/mos/common/fwbundle"
 	"github.com/mongoose-os/mos/mos/flash/cc32xx"
 	"github.com/mongoose-os/mos/mos/flash/common"
-	"github.com/cesanta/errors"
-	"github.com/cesanta/go-serial/serial"
 )
 
 type FlashOpts struct {
 	Port           string
 	FormatSLFSSize int
 	BPIBinary      string
+	KeepFS         bool
 }
 
 const (
@@ -28,6 +29,12 @@ const (
 )
 
 func Flash(fw *fwbundle.FirmwareBundle, opts *FlashOpts) error {
+	if opts.KeepFS {
+		// It's not easy: we create an image that overwrites entire internal flash.
+		// We'd need to read the fs first to preserve it.
+		return errors.Errorf("--keep-fs is not supportef for CC3220")
+	}
+
 	if opts.BPIBinary == "" {
 		bpib, err := findBPIBinary()
 		if err != nil {

--- a/mos/flash/cc3220/ucf_image_builder.go
+++ b/mos/flash/cc3220/ucf_image_builder.go
@@ -13,11 +13,11 @@ import (
 	"runtime"
 	"sort"
 
-	"github.com/mongoose-os/mos/common/fwbundle"
-	"github.com/mongoose-os/mos/mos/ourutil"
-	"github.com/mongoose-os/mos/mos/flash/cc32xx"
 	"github.com/cesanta/errors"
 	"github.com/golang/glog"
+	"github.com/mongoose-os/mos/common/fwbundle"
+	"github.com/mongoose-os/mos/mos/flash/cc32xx"
+	"github.com/mongoose-os/mos/mos/ourutil"
 )
 
 const (

--- a/mos/flash/esp/esp.go
+++ b/mos/flash/esp/esp.go
@@ -38,6 +38,7 @@ type FlashOpts struct {
 	BootFirmware           bool
 	ESP32EncryptionKeyFile string
 	ESP32FlashCryptConf    uint32
+	KeepFS                 bool
 }
 
 type RegReaderWriter interface {

--- a/mos/flash/esp/flasher/flash.go
+++ b/mos/flash/esp/flasher/flash.go
@@ -39,7 +39,6 @@ const (
 	flashBlockSize    = 0x10000
 	sysParamsPartType = "sys_params"
 	sysParamsAreaSize = 4 * flashSectorSize
-	fsDirPartTye      = "fs_dir"
 	espImageMagicByte = 0xe9
 )
 
@@ -65,6 +64,10 @@ func enDis(enabled bool) string {
 }
 
 func Flash(ct esp.ChipType, fw *fwbundle.FirmwareBundle, opts *esp.FlashOpts) error {
+
+	if opts.KeepFS && opts.EraseChip {
+		return errors.Errorf("--keep-fs and --esp-erase-chip are incompatible")
+	}
 
 	cfr, err := ConnectToFlasherClient(ct, opts)
 	if err != nil {
@@ -103,7 +106,7 @@ func Flash(ct esp.ChipType, fw *fwbundle.FirmwareBundle, opts *esp.FlashOpts) er
 	// Sort images by address
 	var images []*image
 	for _, p := range fw.Parts {
-		if p.Type == fsDirPartTye {
+		if p.Type == fwbundle.FSPartType && opts.KeepFS {
 			continue
 		}
 		data, err := fw.GetPartData(p.Name)

--- a/mos/flash/stm32/flasher-share.go
+++ b/mos/flash/stm32/flasher-share.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mongoose-os/mos/common/fwbundle"
-	"github.com/mongoose-os/mos/mos/ourutil"
-	"github.com/mongoose-os/mos/mos/flash/common"
 	"github.com/cesanta/errors"
 	"github.com/golang/glog"
+	"github.com/mongoose-os/mos/common/fwbundle"
+	"github.com/mongoose-os/mos/mos/flash/common"
+	"github.com/mongoose-os/mos/mos/ourutil"
 )
 
 var (
@@ -56,9 +56,16 @@ func getSTLinkMountsInDir(dir string) ([]string, error) {
 type FlashOpts struct {
 	ShareName string
 	Timeout   time.Duration
+	KeepFS    bool
 }
 
 func Flash(fw *fwbundle.FirmwareBundle, opts *FlashOpts) error {
+	if opts.KeepFS {
+		// It's not easy: fs is included in the big blob.
+		// We'd need to read the fs first to preserve it.
+		return errors.Errorf("--keep-fs is not supportef for STM32")
+	}
+
 	data, err := fw.GetPartData("app")
 	if err != nil {
 		return errors.Annotatef(err, "invalid manifest")


### PR DESCRIPTION
Only supported for ESP32, ESP8266 and RS14100.
CC32XX and STM32 are not yet supported due to complicated flashing process.

Closes https://github.com/cesanta/mos-tool/issues/27

CL: Add --keep-fs: a flag to preserve existing FS while flashing