### PR TITLE
Update README.md to reflect repository move

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ command should be `sudo apt-get install mos-latest`
 Use PKGBUILD:
 
 ```bash
-$ git clone https://github.com/cesanta/mos-tool
-$ cd mos-tool/mos/archlinux_pkgbuild/mos-release
+$ git clone https://github.com/mongoose-os/mos
+$ cd mos/mos/archlinux_pkgbuild/mos-release/
 $ makepkg
 $ pacman -U ./mos-*.tar.xz
 ```

--- a/mos/archlinux_pkgbuild/mos-release/PKGBUILD
+++ b/mos/archlinux_pkgbuild/mos-release/PKGBUILD
@@ -16,7 +16,7 @@ makedepends=(
 )
 conflicts=('mos-latest')
 
-source=(git+https://github.com/cesanta/mos-tool.git#tag=${MOS_TAG})
+source=(git+https://github.com/mongoose-os/mos#tag=${MOS_TAG})
 
 md5sums=('SKIP')
 


### PR DESCRIPTION
The old instructions result in `cd: mos-tool/mos/archlinux_pkgbuild/mos-release: No such file or directory`, as the repository has moved here (according to  mos-tool/README.md). 

closes #9, closes #5.