### PR TITLE
Update PKGBUILD's MOS tag

### DIFF
--- a/mos/archlinux_pkgbuild/mos-release/PKGBUILD
+++ b/mos/archlinux_pkgbuild/mos-release/PKGBUILD
@@ -1,4 +1,4 @@
-MOS_TAG=2.13.1
+MOS_TAG=2.14.0
 
 pkgname=mos
 pkgver=${MOS_TAG}


### PR DESCRIPTION
According to #11. 
Fixes mos-release.