### PR TITLE
Optimize handling of non-existing binary lib variants

### DIFF
--- a/mos/build/swmodule.go
+++ b/mos/build/swmodule.go
@@ -308,7 +308,7 @@ func fetchGitHubAsset(loc, owner, repo, tag, assetName string) ([]byte, error) {
 			}
 		}
 		if assetURL == "" {
-			return nil, errors.Errorf("%s/%s: no asset %s found in release %s", owner, repo, assetName, tag)
+			return nil, errors.Annotatef(os.ErrNotExist, "%s/%s: no asset %s found in release %s", owner, repo, assetName, tag)
 		}
 	} else {
 		return nil, errors.Errorf("got %d status code when fetching %s (note: private repos may need --gh-token)", resp.StatusCode, relMetaURL)
@@ -358,7 +358,7 @@ func (m *SWModule) FetchPrebuiltBinary(platform, defaultVersion, tgt string) err
 		var data []byte
 		for i := 1; i <= 3; i++ {
 			data, err = fetchGitHubAsset(m.Location, pp[0], pp[1], version, assetName)
-			if err == nil {
+			if err == nil || os.IsNotExist(errors.Cause(err)) {
 				break
 			}
 			// Sometimes asset downloads fail. GitHub doesn't like us, or rate limiting or whatever.

--- a/mos/build_local.go
+++ b/mos/build_local.go
@@ -34,16 +34,16 @@ import (
 
 	"context"
 
+	"github.com/cesanta/errors"
+	"github.com/golang/glog"
 	"github.com/mongoose-os/mos/common/multierror"
 	"github.com/mongoose-os/mos/common/ourio"
-	"github.com/mongoose-os/mos/mos/ourutil"
 	"github.com/mongoose-os/mos/mos/build"
 	moscommon "github.com/mongoose-os/mos/mos/common"
 	"github.com/mongoose-os/mos/mos/interpreter"
 	"github.com/mongoose-os/mos/mos/manifest_parser"
 	"github.com/mongoose-os/mos/mos/mosgit"
-	"github.com/cesanta/errors"
-	"github.com/golang/glog"
+	"github.com/mongoose-os/mos/mos/ourutil"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -138,8 +138,8 @@ func buildLocal2(ctx context.Context, bParams *buildParams, clean bool) (err err
 
 	manifest, fp, err := manifest_parser.ReadManifestFinal(
 		appDir, &bParams.ManifestAdjustments, logWriter, interp,
-		&manifest_parser.ReadManifestCallbacks{ComponentProvider: &compProvider}, true, *preferPrebuiltLibs,
-	)
+		&manifest_parser.ReadManifestCallbacks{ComponentProvider: &compProvider},
+		true /* requireArch */, *preferPrebuiltLibs, *libsUpdateInterval)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/mos/eval_manifest_expr.go
+++ b/mos/eval_manifest_expr.go
@@ -25,11 +25,11 @@ import (
 
 	"context"
 
+	"github.com/cesanta/errors"
 	"github.com/mongoose-os/mos/mos/dev"
 	"github.com/mongoose-os/mos/mos/flags"
 	"github.com/mongoose-os/mos/mos/interpreter"
 	"github.com/mongoose-os/mos/mos/manifest_parser"
-	"github.com/cesanta/errors"
 	flag "github.com/spf13/pflag"
 )
 
@@ -94,7 +94,8 @@ func evalManifestExpr(ctx context.Context, devConn dev.DevConn) error {
 			Platform:  bParams.Platform,
 			BuildVars: buildVarsCli,
 		}, logWriter, interp,
-		&manifest_parser.ReadManifestCallbacks{ComponentProvider: &compProvider}, false, *preferPrebuiltLibs,
+		&manifest_parser.ReadManifestCallbacks{ComponentProvider: &compProvider},
+		false /* requireArch */, *preferPrebuiltLibs, 0, /* binaryLibsUpdateInterval */
 	)
 	if err != nil {
 		return errors.Trace(err)

--- a/mos/manifest_parser/manifest_parser_test.go
+++ b/mos/manifest_parser/manifest_parser_test.go
@@ -160,7 +160,7 @@ func singleManifestTest(t *testing.T, appPath string) error {
 				Platform:  platform,
 				BuildVars: descr.BuildVars,
 			}, logWriter, interp,
-			&ReadManifestCallbacks{ComponentProvider: &compProviderTest{}}, true, descr.PreferBinaryLibs,
+			&ReadManifestCallbacks{ComponentProvider: &compProviderTest{}}, true, descr.PreferBinaryLibs, 0,
 		)
 
 		expectedErrorFilename := filepath.Join(appPath, expectedDir, platform, errorTextFile)


### PR DESCRIPTION
If a variant does not exist, create a local tombstone file (zero-sized) and don't try to fetch on subsequent builds.

Also, when using latest, re-fetch binary libs every --libs-update-interval (currently this logic only applies to pulls)

CL: mos: Optimize handling of non-existing binary lib variants