### PR TITLE
Add ability to embed extra data in FW bundles using --extra-attr

### DIFF
--- a/mos/common/common.go
+++ b/mos/common/common.go
@@ -4,6 +4,7 @@
 package moscommon
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/cesanta/errors"
@@ -44,4 +45,32 @@ func ParseParamValues(args []string) (map[string]string, error) {
 		ret[subs[0]] = subs[1]
 	}
 	return ret, nil
+}
+
+func ParseParamValuesTyped(args []string) (map[string]interface{}, error) {
+	var res map[string]interface{}
+	params, err := ParseParamValues(args)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for p, valueStr := range params {
+		var value interface{}
+		switch valueStr {
+		case "true":
+			value = true
+		case "false":
+			value = false
+		default:
+			if i, err := strconv.ParseInt(valueStr, 0, 64); err == nil {
+				value = i
+			} else {
+				value = valueStr
+			}
+		}
+		if res == nil {
+			res = make(map[string]interface{})
+		}
+		res[p] = value
+	}
+	return res, nil
 }

--- a/mos/create_fw_bundle/create_fw_bundle.go
+++ b/mos/create_fw_bundle/create_fw_bundle.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	moscommon "github.com/mongoose-os/mos/mos/common"
@@ -114,26 +113,17 @@ func CreateFWBundle(ctx context.Context, devConn dev.DevConn) error {
 			}
 		}
 	}
-	attrs, err := moscommon.ParseParamValues(*flags.Attr)
+	attrs, err := moscommon.ParseParamValuesTyped(*flags.Attr)
 	if err != nil {
 		return errors.Annotatef(err, "failed to parse --attr")
 	}
-	for attr, valueStr := range attrs {
-		var value interface{}
-		switch valueStr {
-		case "true":
-			value = true
-		case "false":
-			value = false
-		default:
-			if i, err := strconv.ParseInt(valueStr, 0, 64); err == nil {
-				value = i
-			} else {
-				value = valueStr
-			}
-		}
+	for attr, value := range attrs {
 		fwb.SetAttr(attr, value)
 	}
+	extraAttrs, err := moscommon.ParseParamValuesTyped(*flags.ExtraAttr)
+	if err != nil {
+		return errors.Annotatef(err, "failed to parse --extra-attr")
+	}
 	ourutil.Reportf("Writing %s", *flags.Output)
-	return fwbundle.WriteZipFirmwareBundle(fwb, *flags.Output, *flags.Compress)
+	return fwbundle.WriteZipFirmwareBundle(fwb, *flags.Output, *flags.Compress, extraAttrs)
 }

--- a/mos/flags/flags.go
+++ b/mos/flags/flags.go
@@ -90,7 +90,8 @@ var (
 	KeepTempFiles = flag.Bool("keep-temp-files", false, "keep temp files after the build is done (by default they are in ~/.mos/tmp)")
 	KeepFS        = flag.Bool("keep-fs", false, "When flashing, skip the filesystem parts")
 
-	Attr = flag.StringArray("attr", []string{}, "manifest attribute, can be used multiple times")
+	Attr      = flag.StringArray("attr", nil, "manifest attribute, can be used multiple times")
+	ExtraAttr = flag.StringArray("extra-attr", nil, "manifest extra attribute info to be added to ZIP")
 )
 
 func Platform() string {


### PR DESCRIPTION
Data is embedded as a JSON string with attibute ID 0x293a

Example:

  $ mos create-fw-bundle -o test.zip --extra-attr foo=bar --extra-attr bar=123 ...

Will embed `{"bar":123,"foo":"bar"}` in the manifest's extra field.

This mechanism will later be used for manifest signatures.

CL: mos: Add ability to embed extra data in FW bundles using --extra-attr