### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ Use PKGBUILD:
 ```bash
 $ git clone https://github.com/mongoose-os/mos
 $ cd mos/tools/archlinux_pkgbuild/mos-release
-$ sudo pacman -Sy gcc go git jq make pkgconf python3
-$ makepkg
-$ pacman -U ./mos-*.tar.xz
+$ makepkg -fsri
 ```
 
 Note: to use the very latest version from the git repo, instead of the released


### PR DESCRIPTION
To add to #53, I'm also updating README instructions in this separate PR.

* No need to install dependencies beforehand. PKGBUILD's `makedepends` is supposed to do that when you use `makepkg --syncdeps`
* Also, shorten install command so it builds and installs without extra commands.