### PR TITLE
Modified Arch Linux PKGBUILD to remove unnecessary output

### DIFF
--- a/tools/archlinux_pkgbuild/mos-latest/PKGBUILD
+++ b/tools/archlinux_pkgbuild/mos-latest/PKGBUILD
@@ -22,7 +22,8 @@ source=(git+https://github.com/mongoose-os/mos.git#branch=master)
 md5sums=('SKIP')
 
 pkgver() {
-  make -C "$srcdir/mos" clean-version get-version
+  make -C "$srcdir/mos" clean-version version/version.json > /dev/null
+  make -s -C "$srcdir/mos" get-version
 }
 
 build() {


### PR DESCRIPTION
As mentioned in #6 the call to `make clean-version get-version` creates a lot of additional output apart from the version. The first line with the call to `clean-version version/version.json` makes sure the `version/version.json` target is already built so it doesn't create additional output in the `make get-version` call. I'm sure this could be solved more elegantly in the Makefile but I was unsure about other build commands which might be dependent on that exact behavior so I just created this workaround in the PKGBUILD. This is my first time working with PKGBUILD and Makefiles so please correct me, if there is a more suitable way to solve this.