### PR TITLE
Update swmodule_github.go download over socks5 proxy

### DIFF
--- a/cli/build/swmodule_github.go
+++ b/cli/build/swmodule_github.go
@@ -92,8 +92,17 @@ func fetchGitHubAsset(loc, host, repoPath, tag, assetName, token string) ([]byte
 func fetchAssetFromURL(host, assetName, tag, assetURL, token string) ([]byte, error) {
 	ourutil.Reportf("Fetching %s (%s) from %s...", assetName, tag, assetURL)
 
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", assetURL, nil)
+	client := &http.Client{
+		Timeout: time.Second * 600,
+	}
+	sock5Proxy := os.Getenv("SOCK5_PROXY")
+        if sock5Proxy != "" {
+                proxyUrl, _ := url.Parse(sock5Proxy)
+                client.Transport = &http.Transport{
+                        Proxy: http.ProxyURL(proxyUrl),
+                }
+        }
+	req, _ := http.NewRequest("GET", assetURL, nil)
 	req.Header.Add("Accept", "application/octet-stream")
 	if token != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("token %s", token)) // GitHub


### PR DESCRIPTION
In some area(China MainLand), network is watching by GFW, you know it's very hard to down pre-build libs.

Just put env in .bashrc:

SOCK5_PROXY=socks5://127.0.0.1:2080

mos will use this env var to download pre-build libs on Github over this proxy.